### PR TITLE
Version 5.4.3

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,5 @@
 class rubymine (
-  $version = '5.4.2',
+  $version = '5.4.3',
 ) {
   package { 'RubyMine':
     provider => 'appdmg',


### PR DESCRIPTION
Bumped downlaod version to 5.4.3

Previous version, 5.4.2, is no longer available via the download link on the Rubymine website.
