### PR TITLE
New version of RubyMine

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,5 @@
 class rubymine (
-  $version = '6.0',
+  $version = '6.3',
 ) {
   package { 'RubyMine':
     provider => 'appdmg',


### PR DESCRIPTION
JetBrains launched a new version of RubyMine a couple of days ago. This change should sort that out.
